### PR TITLE
v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change log
 
-## UNRELEASED
+## [v0.4.0 2025-03-22](https://github.com/TomMonks/forecast-tools/releases/tag/v0.4.0)
 
-### [v0.4.0 2025-03-22](https://github.com/TomMonks/forecast-tools/releases/tag/v0.4.0)
+### Changed
 
 * BREAKING: dropped Python 3.8 support
 * BREAKING: Unified interface to `winkler_score`, `absolute_coverage_difference` and `coverage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+## 0.4.1
+
+## Changed
+
+* All point forecast metrics now validate inputs and raise `ValueError` or `TypeError` when `y_true` and `y_pred` do not meet specifications
+* `mean_absolute_percentage_error` and `symmetric_mean_absolute_percentage_error` now raise user warnings when values are close to zero. i.e. inflation of metrics can occur.
+
+## Fixed
+
+* PATCH: point forecast metrics can now handle edge case where `y_true` and `y_pred` inputs are different data types (e.g. `pd.Series` and `np.array`). Prior to v0.4.1 this generated an incorrect metric.  
+
 ## [v0.4.0 2025-03-22](https://github.com/TomMonks/forecast-tools/releases/tag/v0.4.0)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-### Changed
+### [v0.4.0 2025-03-22](https://github.com/TomMonks/forecast-tools/releases/tag/v0.4.0)
 
 * BREAKING: dropped Python 3.8 support
 * BREAKING: Unified interface to `winkler_score`, `absolute_coverage_difference` and `coverage`

--- a/forecast_tools/__init__.py
+++ b/forecast_tools/__init__.py
@@ -4,5 +4,5 @@ forecast_tools.
 A python framework to support education, research and practice of forecasting
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = 'Thomas Monks'

--- a/forecast_tools/metrics.py
+++ b/forecast_tools/metrics.py
@@ -26,27 +26,44 @@ from forecast_tools.baseline import SNaive
 
 def as_arrays(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Returns ground truth and predictions
-    values as numpy arrays.
-
+    Returns ground truth and predictions values as numpy arrays.
+    
     Parameters:
     --------
     y_true -- array-like
         actual observations from time series
     y_pred -- array-like
         the predictions
-
+    
     Returns:
     -------
     Tuple(np.array np.array)
-
-    Notes:
-    -----
-    Patched in v0.4.1 to flatten arrays. This handles edge case
-    where y_true and y_pred are different data structures e.g.
-    an array and a dataframe.
+    
+    Raises:
+    ------
+    ValueError
+        If inputs cannot be converted to arrays or have different lengths
+    TypeError
+        If inputs are not array-like
     """
-    return np.asarray(y_true).flatten(), np.asarray(y_pred).flatten()
+    if not hasattr(y_true, '__iter__') or not hasattr(y_pred, '__iter__'):
+        raise TypeError("Inputs must be iterable (array-like) objects")
+
+    try:
+        y_true_arr = np.asarray(y_true).flatten()
+        y_pred_arr = np.asarray(y_pred).flatten()
+    except ValueError as e:
+        raise ValueError(f"Inputs cannot be converted to arrays: {str(e)}")
+    
+    if len(y_true_arr) != len(y_pred_arr):
+        raise ValueError(f"Input arrays must have the same length. Got {len(y_true_arr)} and {len(y_pred_arr)}")
+    
+    if len(y_true_arr) == 0:
+        raise ValueError("Input arrays cannot be empty")
+        
+    return y_true_arr, y_pred_arr
+
+
 
 
 def mean_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
@@ -101,21 +118,32 @@ def mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike)
 def mean_absolute_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Mean Absolute Error (MAE)
-
+    
     Parameters:
     --------
     y_true -- array-like
         actual observations from time series
     y_pred -- arraylike
         the predictions to evaluate
-
+    
     Returns:
     -------
     float,
         scalar value representing the MAE
+        
+    Raises:
+    ------
+    ValueError
+        If inputs cannot be converted to numeric arrays
     """
-    y_true, y_pred = as_arrays(y_true, y_pred)
-    return np.mean(np.abs((y_true - y_pred)))
+    y_true_arr, y_pred_arr = as_arrays(y_true, y_pred)
+    
+    # Check if arrays contain numeric data
+    if not np.issubdtype(y_true_arr.dtype, np.number) or not np.issubdtype(y_pred_arr.dtype, np.number):
+        raise ValueError("Input arrays must contain numeric values")
+        
+    return np.mean(np.abs((y_true_arr - y_pred_arr)))
+
 
 
 def mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:

--- a/forecast_tools/metrics.py
+++ b/forecast_tools/metrics.py
@@ -226,36 +226,62 @@ def root_mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> flo
     return np.sqrt(mean_squared_error(y_true, y_pred))
 
 
-def symmetric_mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) ->float:
+def symmetric_mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Symmetric Mean Absolute Percentage Error (sMAPE)
 
-    A proposed improvement./replacement for MAPE.  (But still not symmetric).
+    A proposed improvement/replacement for MAPE. Despite its name, it is not perfectly symmetric.
 
-    Computation based on Hyndsight blog:
-    https://robjhyndman.com/hyndsight/smape/
+    Computation based on formula: 
+    sMAPE = (1/n) * Σ(2|y_true - y_pred| / (|y_true| + |y_pred|)) * 100
 
     Limitations of sMAPE:
-
-    1. When the ground true value is close to zero MAPE is inflated.
-    2. Like MAPE it is not symmetric.
+    1. When values are close to zero, sMAPE can be inflated.
+    2. When either y_true or y_pred is zero, the formula can produce undefined results.
+    3. It is bounded between 0% and 200%.
+    4. It treats over-forecasting and under-forecasting differently.
 
     Parameters:
     --------
     y_true -- array-like
         actual observations from time series
-    y_pred -- arraylike
+    y_pred -- array-like
         the predictions to evaluate
 
     Returns:
     -------
     float,
-        scalar value representing the RMSE
+        scalar value representing the sMAPE (0-200)
+        
+    Raises:
+    ------
+    ValueError
+        If inputs contain zeros, cannot be converted to numeric arrays, or have different lengths
+    TypeError
+        If inputs are not array-like
     """
-    y_true, y_pred = as_arrays(y_true, y_pred)
-    numerator = 2 * np.abs(y_true - y_pred)
-    denominator = np.abs(y_pred) + np.abs(y_true)
+    y_true_arr, y_pred_arr = as_arrays(y_true, y_pred)
+    
+    # Check if arrays contain numeric data
+    if not np.issubdtype(y_true_arr.dtype, np.number) or not np.issubdtype(y_pred_arr.dtype, np.number):
+        raise ValueError("Input arrays must contain numeric values")
+    
+    # Check for division by zero
+    denominator = np.abs(y_pred_arr) + np.abs(y_true_arr)
+    if np.any(denominator == 0):
+        raise ValueError("sMAPE cannot be calculated when both y_true and y_pred contain zeros at the same index")
+    
+    # Check for very small denominators that might cause numerical instability
+    small_values = denominator < 1e-10
+    if np.any(small_values):
+        warnings.warn(
+            "Some values in y_true and y_pred sum to a very small number (<1e-10), which may lead to inflated sMAPE values",
+            UserWarning
+        )
+    
+    numerator = 2 * np.abs(y_true_arr - y_pred_arr)
     return np.mean(100 * (numerator / denominator))
+
 
 
 def mean_absolute_scaled_error(

--- a/forecast_tools/metrics.py
+++ b/forecast_tools/metrics.py
@@ -24,9 +24,9 @@ from typing import Optional, Dict, Tuple, List, Union
 from forecast_tools.baseline import SNaive
 
 
-def as_arrays(y_true, y_pred):
+def as_arrays(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Returns ground truth and predict
+    Returns ground truth and predictions
     values as numpy arrays.
 
     Parameters:
@@ -39,19 +39,25 @@ def as_arrays(y_true, y_pred):
     Returns:
     -------
     Tuple(np.array np.array)
+
+    Notes:
+    -----
+    Patched in v0.4.1 to flatten arrays. This handles edge case
+    where y_true and y_pred are different data structures e.g.
+    an array and a dataframe.
     """
-    return np.asarray(y_true), np.asarray(y_pred)
+    return np.asarray(y_true).flatten(), np.asarray(y_pred).flatten()
 
 
-def mean_error(y_true, y_pred):
+def mean_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Computes Mean Error (ME).
 
     Parameters:
     --------
-    y_true -- array-like
+    y_true: array-like
         actual observations from time series
-    y_pred -- arraylike
+    y_pred: arraylike
         the predictions to evaluate
 
     Returns:
@@ -63,7 +69,7 @@ def mean_error(y_true, y_pred):
     return np.mean(y_true - y_pred)
 
 
-def mean_absolute_percentage_error(y_true, y_pred):
+def mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Mean Absolute Percentage Error (MAPE).
 
@@ -78,9 +84,9 @@ def mean_absolute_percentage_error(y_true, y_pred):
 
     Parameters:
     --------
-    y_true -- array-like
+    y_true: array-like
         actual observations from time series
-    y_pred -- arraylike
+    y_pred: arraylike
         the predictions to evaluate
 
     Returns:
@@ -92,7 +98,7 @@ def mean_absolute_percentage_error(y_true, y_pred):
     return np.mean(np.abs((y_true - y_pred) / y_true)) * 100
 
 
-def mean_absolute_error(y_true, y_pred):
+def mean_absolute_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Mean Absolute Error (MAE)
 
@@ -112,7 +118,7 @@ def mean_absolute_error(y_true, y_pred):
     return np.mean(np.abs((y_true - y_pred)))
 
 
-def mean_squared_error(y_true, y_pred):
+def mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Mean Squared Error (MSE)
 
@@ -132,7 +138,7 @@ def mean_squared_error(y_true, y_pred):
     return np.mean(np.square((y_true - y_pred)))
 
 
-def root_mean_squared_error(y_true, y_pred):
+def root_mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     """
     Root Mean Squared Error (RMSE).
 
@@ -154,7 +160,7 @@ def root_mean_squared_error(y_true, y_pred):
     return np.sqrt(mean_squared_error(y_true, y_pred))
 
 
-def symmetric_mean_absolute_percentage_error(y_true, y_pred):
+def symmetric_mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) ->float:
     """
     Symmetric Mean Absolute Percentage Error (sMAPE)
 
@@ -186,7 +192,12 @@ def symmetric_mean_absolute_percentage_error(y_true, y_pred):
     return np.mean(100 * (numerator / denominator))
 
 
-def mean_absolute_scaled_error(y_true, y_pred, y_train, period=None):
+def mean_absolute_scaled_error(
+        y_true: npt.ArrayLike, 
+        y_pred: npt.ArrayLike, 
+        y_train:npt.ArrayLike, 
+        period: Optional[int] = None
+) -> float:
     """
     Mean absolute scaled error (MASE)
 
@@ -229,7 +240,11 @@ def mean_absolute_scaled_error(y_true, y_pred, y_train, period=None):
     return mean_absolute_error(y_true, y_pred) / mae_insample
 
 
-def forecast_errors(y_true, y_pred, metrics="all"):
+def forecast_errors(
+        y_true: npt.ArrayLike, 
+        y_pred:npt.ArrayLike, 
+        metrics: Union[str, List[str]] = "all"
+) -> dict:
     """
     Convenience function for return a multiple
     forecast errors
@@ -277,7 +292,7 @@ def forecast_errors(y_true, y_pred, metrics="all"):
     return errors
 
 
-def _forecast_error_functions():
+def _forecast_error_functions() -> dict:
     """
     Return all forecast functions in
     a dict

--- a/forecast_tools/metrics.py
+++ b/forecast_tools/metrics.py
@@ -17,6 +17,7 @@ absolute_coverage_difference - difference of coverage from target
 import numpy as np
 import pandas as pd
 import numbers
+import warnings
 
 import numpy.typing as npt
 from typing import Optional, Dict, Tuple, List, Union
@@ -95,9 +96,9 @@ def mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike)
     Limitations of MAPE ->
 
     1. When the ground true value is close to zero MAPE is inflated.
-
-    2. MAPE is not symmetric.  MAPE produces smaller forecast
-    errors when underforecasting.
+    2. MAPE is not symmetric. MAPE produces smaller forecast
+       errors when underforecasting.
+    3. MAPE cannot be calculated when actual values contain zeros.
 
     Parameters:
     --------
@@ -110,9 +111,35 @@ def mean_absolute_percentage_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike)
     -------
     float,
         scalar value representing the MAPE (0-100)
+        
+    Raises:
+    ------
+    ValueError
+        If y_true contains zeros or non-numeric values
+        If inputs have different lengths or are empty
+    TypeError
+        If inputs are not array-like
     """
-    y_true, y_pred = as_arrays(y_true, y_pred)
-    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100
+    y_true_arr, y_pred_arr = as_arrays(y_true, y_pred)
+    
+    # Check if arrays contain numeric data
+    if not np.issubdtype(y_true_arr.dtype, np.number) or not np.issubdtype(y_pred_arr.dtype, np.number):
+        raise ValueError("Input arrays must contain numeric values")
+    
+    # Check for zeros in y_true which would cause division by zero
+    if np.any(y_true_arr == 0):
+        raise ValueError("MAPE cannot be calculated when actual values (y_true) contain zeros")
+    
+    # Optional: Check for very small values that might cause numerical instability
+    small_values = np.abs(y_true_arr) < 1e-10
+    if np.any(small_values):
+        warnings.warn(
+            "Some values in y_true are very close to zero (<1e-10), which may lead to inflated MAPE values",
+            UserWarning
+        )
+    
+    return np.mean(np.abs((y_true_arr - y_pred_arr) / y_true_arr)) * 100
+
 
 
 def mean_absolute_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:

--- a/forecast_tools/metrics.py
+++ b/forecast_tools/metrics.py
@@ -181,16 +181,28 @@ def mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
     --------
     y_true -- array-like
         actual observations from time series
-    y_pred -- arraylike
+    y_pred -- array-like
         the predictions to evaluate
 
     Returns:
     -------
     float,
         scalar value representing the MSE
+
+    Raises:
+    ------
+    ValueError
+        If inputs cannot be converted to numeric arrays or have different lengths
+    TypeError
+        If inputs are not array-like
     """
-    y_true, y_pred = as_arrays(y_true, y_pred)
-    return np.mean(np.square((y_true - y_pred)))
+    y_true_arr, y_pred_arr = as_arrays(y_true, y_pred)
+    
+    # Check if arrays contain numeric data
+    if not np.issubdtype(y_true_arr.dtype, np.number) or not np.issubdtype(y_pred_arr.dtype, np.number):
+        raise ValueError("Input arrays must contain numeric values")
+    
+    return np.mean(np.square((y_true_arr - y_pred_arr)))
 
 
 def root_mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> float:
@@ -211,7 +223,6 @@ def root_mean_squared_error(y_true: npt.ArrayLike, y_pred: npt.ArrayLike) -> flo
     float,
         scalar value representing the RMSE
     """
-    y_true, y_pred = as_arrays(y_true, y_pred)
     return np.sqrt(mean_squared_error(y_true, y_pred))
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -273,22 +273,60 @@ def test_error_metrics_exceptions(y_true, y_pred, exception):
 
 
 
-@pytest.mark.parametrize("y_pred, y_true, expected",
-                         [([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
-                          ([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12],
-                           99.5634920634921),
-                          ([103, 130, 132, 124, 124, 108],
-                           [129, 111, 122, 129, 110, 141],
-                           14.7466414897349),
-                          ([103, 130, 132, 124, 124, 108, 160, 160],
-                           [129, 111, 122, 129, 110, 141, 142, 143],
-                           13.9526876064932)])
-def test_symmetric_mape(y_true, y_pred, expected):
+@pytest.mark.parametrize("y_true, y_pred, expected", [
+    # Original test cases (with corrected parameter order)
+    ([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
+    ([7, 8, 9, 10, 11, 12], [1, 2, 3, 4, 5, 6], 99.5634920634921),
+    ([129, 111, 122, 129, 110, 141], [103, 130, 132, 124, 124, 108], 14.7466414897349),
+    ([129, 111, 122, 129, 110, 141, 142, 143], [103, 130, 132, 124, 124, 108, 160, 160], 13.9526876064932),
+    
+    # Additional test cases with different data types
+    (np.array([1, 2, 3, 4, 5, 6]), np.array([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.Series([7, 8, 9, 10, 11, 12]), pd.Series([1, 2, 3, 4, 5, 6]), 99.5634920634921),
+    (pd.Series([129, 111, 122, 129, 110, 141]), [103, 130, 132, 124, 124, 108], 14.7466414897349),
+])
+def test_symmetric_mean_absolute_percentage_error(y_true, y_pred, expected):
     '''
-    test symmetric mean absolute percentage error calculation
+    Test symmetric mean absolute percentage error calculation with various input types
     '''
     error = m.symmetric_mean_absolute_percentage_error(y_true, y_pred)
-    assert pytest.approx(expected) == error
+    assert pytest.approx(expected, rel=1e-9) == error
+
+# Tests for error handling
+@pytest.mark.parametrize("y_true, y_pred, exception", [
+    # Different lengths
+    ([1, 2, 3], [1, 2], ValueError),
+    
+    # Empty arrays
+    ([], [], ValueError),
+    
+    # Non-numeric values
+    (["a", "b", "c"], [1, 2, 3], ValueError),
+    ([1, 2, 3], ["a", "b", "c"], ValueError),
+    
+    # Non-array-like objects
+    (123, [1, 2, 3], TypeError),
+    ([1, 2, 3], None, TypeError),
+    
+    # Division by zero cases (when both values are zero)
+    ([0], [0], ValueError),
+    ([1, 0, 3], [1, 0, 3], ValueError),
+])
+def test_symmetric_mean_absolute_percentage_error_exceptions(y_true, y_pred, exception):
+    '''
+    Test symmetric mean absolute percentage error raises appropriate exceptions for invalid inputs
+    '''
+    with pytest.raises(exception):
+        m.symmetric_mean_absolute_percentage_error(y_true, y_pred)
+
+# Test for warning with very small values
+def test_symmetric_mean_absolute_percentage_error_warnings():
+    '''
+    Test warnings for very small values that might cause numerical instability
+    '''
+    with pytest.warns(UserWarning):
+        m.symmetric_mean_absolute_percentage_error([1e-11], [1e-11])
+
 
 
 @pytest.mark.parametrize("y_true, y_intervals, expected",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -178,40 +178,99 @@ def test_mean_absolute_percentage_error_warnings():
         m.mean_absolute_percentage_error([1e-11, 1, 2], [0, 1, 2])
 
 
-@pytest.mark.parametrize("y_pred, y_true, expected",
-                         [([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
-                          ([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12],
-                           36.0),
-                          ([103, 130, 132, 124, 124, 108],
-                           [129, 111, 122, 129, 110, 141],
-                           407.833333333333),
-                          ([103, 130, 132, 124, 124, 108, 160, 160],
-                           [129, 111, 122, 129, 110, 141, 142, 143],
-                           382.50)])
+@pytest.mark.parametrize("y_true, y_pred, expected", [
+    # Original test cases
+    ([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
+    ([7, 8, 9, 10, 11, 12], [1, 2, 3, 4, 5, 6], 36.0),
+    ([129, 111, 122, 129, 110, 141], [103, 130, 132, 124, 124, 108], 407.833333333333),
+    ([129, 111, 122, 129, 110, 141, 142, 143], [103, 130, 132, 124, 124, 108, 160, 160], 382.50),
+    
+    # Additional test cases with different data types
+    (np.array([1, 2, 3, 4, 5, 6]), np.array([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.Series([1, 2, 3, 4, 5, 6]), pd.Series([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.DataFrame([1, 2, 3, 4, 5, 6]), pd.Series([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.DataFrame([1, 2, 3, 4, 5, 6]), np.array([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.Series([1, 2, 3, 4, 5, 6]), [1, 2, 3, 4, 5, 6], 0.0),
+    
+    # Test with float values
+    ([1.5, 2.5, 3.5], [1.0, 2.0, 3.0], 0.25),
+    
+    # Test with negative values
+    ([-1, -2, -3], [-4, -5, -6], 9.0),
+    
+    # Test with mixed positive and negative values
+    ([1, -2, 3], [4, -5, 6], 9.0),
+    
+    # Test with 2D arrays (should be flattened)
+    (np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]]), 16.0),
+])
 def test_mean_squared_error(y_true, y_pred, expected):
     '''
-    test mean squared error calculation
+    Test mean squared error calculation with various input types
     '''
     error = m.mean_squared_error(y_true, y_pred)
-    assert pytest.approx(expected) == error
+    assert pytest.approx(expected, rel=1e-9) == error
 
 
-@pytest.mark.parametrize("y_pred, y_true, expected",
-                         [([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
-                          ([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12],
-                           6.0),
-                          ([103, 130, 132, 124, 124, 108],
-                           [129, 111, 122, 129, 110, 141],
-                           20.1948838405506),
-                          ([103, 130, 132, 124, 124, 108, 160, 160],
-                           [129, 111, 122, 129, 110, 141, 142, 143],
-                           19.5576072156079)])
+@pytest.mark.parametrize("y_true, y_pred, expected", [
+    # Original test cases
+    ([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
+    ([7, 8, 9, 10, 11, 12], [1, 2, 3, 4, 5, 6], 6.0),
+    ([129, 111, 122, 129, 110, 141], [103, 130, 132, 124, 124, 108], 20.1948838405506),
+    ([129, 111, 122, 129, 110, 141, 142, 143], [103, 130, 132, 124, 124, 108, 160, 160], 19.5576072156079),
+    
+    # Additional test cases with different data types
+    (np.array([1, 2, 3, 4, 5, 6]), np.array([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.Series([1, 2, 3, 4, 5, 6]), pd.Series([1, 2, 3, 4, 5, 6]), 0.0),
+    (pd.Series([1, 2, 3, 4, 5, 6]), [1, 2, 3, 4, 5, 6], 0.0),
+    
+    # Test with float values
+    ([1.5, 2.5, 3.5], [1.0, 2.0, 3.0], 0.5),
+    
+    # Test with negative values
+    ([-1, -2, -3], [-4, -5, -6], 3.0),
+    
+    # Test with mixed positive and negative values
+    ([1, -2, 3], [4, -5, 6], 3.0),
+    
+    # Test with 2D arrays (should be flattened)
+    (np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]]), 4.0),
+])
 def test_root_mean_squared_error(y_true, y_pred, expected):
     '''
-    test root mean squared error calculation
+    Test root mean squared error calculation with various input types
     '''
     error = m.root_mean_squared_error(y_true, y_pred)
-    assert pytest.approx(expected) == error
+    assert pytest.approx(expected, rel=1e-9) == error
+
+
+# Tests for error handling
+@pytest.mark.parametrize("y_true, y_pred, exception", [
+    # Different lengths
+    ([1, 2, 3], [1, 2], ValueError),
+    
+    # Empty arrays
+    ([], [], ValueError),
+    
+    # Non-numeric values
+    (["a", "b", "c"], [1, 2, 3], ValueError),
+    ([1, 2, 3], ["a", "b", "c"], ValueError),
+    
+    # Non-array-like objects
+    (123, [1, 2, 3], TypeError),
+    ([1, 2, 3], None, TypeError),
+])
+def test_error_metrics_exceptions(y_true, y_pred, exception):
+    '''
+    Test that appropriate exceptions are raised for invalid inputs
+    for both MSE and RMSE functions
+    '''
+    with pytest.raises(exception):
+        m.mean_squared_error(y_true, y_pred)
+    
+    with pytest.raises(exception):
+        m.root_mean_squared_error(y_true, y_pred)
+
 
 
 @pytest.mark.parametrize("y_pred, y_true, expected",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -124,8 +124,14 @@ def test_mean_error(y_true, y_pred, expected):
                           ([103, 130, 132, 124, 124, 108],
                            [129, 111, 122, 129, 110, 141],
                            14.2460623711587),
-                          ([103, 130, 132, 124, 124, 108, 160, 160],
+                          (np.array([103, 130, 132, 124, 124, 108, 160, 160]),
+                           pd.DataFrame([129, 111, 122, 129, 110, 141, 142, 143]),
+                           13.7550678066365),
+                           (pd.Series([103, 130, 132, 124, 124, 108, 160, 160]),
                            [129, 111, 122, 129, 110, 141, 142, 143],
+                           13.7550678066365),
+                           (pd.Series([103, 130, 132, 124, 124, 108, 160, 160]),
+                           np.array([129, 111, 122, 129, 110, 141, 142, 143]),
                            13.7550678066365)])
 def test_mean_absolute_percentage_error(y_true, y_pred, expected):
     '''
@@ -133,6 +139,43 @@ def test_mean_absolute_percentage_error(y_true, y_pred, expected):
     '''
     error = m.mean_absolute_percentage_error(y_true, y_pred)
     assert pytest.approx(expected) == error
+
+
+# Additional tests for error cases
+@pytest.mark.parametrize("y_true, y_pred, exception", [
+    # Different lengths
+    ([100, 200, 300], [100, 200], ValueError),
+    
+    # Empty arrays
+    ([], [], ValueError),
+    
+    # Non-numeric values
+    (["a", "b", "c"], [1, 2, 3], ValueError),
+    ([1, 2, 3], ["a", "b", "c"], ValueError),
+    
+    # Non-array-like objects
+    (123, [1, 2, 3], TypeError),
+    ([1, 2, 3], None, TypeError),
+    
+    # Zeros in y_true (division by zero)
+    ([0, 1, 2], [0, 1, 2], ValueError),
+    ([1, 0, 2], [1, 0, 2], ValueError),
+])
+def test_mean_absolute_percentage_error_exceptions(y_true, y_pred, exception):
+    '''
+    Test mean absolute percentage error raises appropriate exceptions for invalid inputs
+    '''
+    with pytest.raises(exception):
+        m.mean_absolute_percentage_error(y_true, y_pred)
+
+
+# Test for warning with very small values
+def test_mean_absolute_percentage_error_warnings():
+    '''
+    Test warnings for very small values in y_true
+    '''
+    with pytest.warns(UserWarning):
+        m.mean_absolute_percentage_error([1e-11, 1, 2], [0, 1, 2])
 
 
 @pytest.mark.parametrize("y_pred, y_true, expected",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -42,19 +42,64 @@ def test_forecast_error_return_funcs(y_true, y_pred, metrics, expected):
     assert list(funcs_dict.keys()) == expected
 
 
-@pytest.mark.parametrize("y_pred, y_true, expected",
-                         [([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
-                          ([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], 6.0),
-                          ([103, 130, 132, 124, 124, 108],
-                           [129, 111, 122, 129, 110, 141], 17.833333),
-                          ([103, 130, 132, 124, 124, 108, 160, 160],
-                           [129, 111, 122, 129, 110, 141, 142, 143], 17.75)])
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        # Basic test cases with lists
+        ([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], 0.0),
+        ([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], 6.0),
+        ([103, 130, 132, 124, 124, 108], [129, 111, 122, 129, 110, 141], 17.833333),
+        
+        # Different array-like data types
+        (np.array([1, 2, 3]), np.array([4, 5, 6]), 3.0),
+        (pd.Series([1, 2, 3]), [4, 5, 6], 3.0),
+        ([1, 2, 3], pd.Series([4, 5, 6]), 3.0),
+        (pd.DataFrame([1, 2, 3]), pd.DataFrame([4, 5, 6]), 3.0),
+        (pd.DataFrame([1, 2, 3]), pd.Series([4, 5, 6]), 3.0),
+        (pd.DataFrame([1, 2, 3]), np.array([4, 5, 6]), 3.0),
+        
+        # Float values
+        ([1.5, 2.5, 3.5], [1.0, 2.0, 3.0], 0.5),
+        
+        # Mixed types
+        ([1, 2, 3], [1.5, 2.5, 3.5], 0.5),
+        
+        # 2D arrays (should be flattened)
+        (np.array([[1, 2], [3, 4]]), np.array([[5, 6], [7, 8]]), 4.0),
+    ]
+)
 def test_mean_absolute_error(y_true, y_pred, expected):
     '''
-    test mean absolute error calculation
+    Test mean absolute error calculation with various input types
     '''
     error = m.mean_absolute_error(y_true, y_pred)
     assert pytest.approx(expected) == error
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, exception",
+    [
+        # Different lengths
+        ([1, 2, 3], [1, 2], ValueError),
+        
+        # Empty arrays
+        ([], [], ValueError),
+        
+        # Non-numeric values
+        (["a", "b", "c"], [1, 2, 3], ValueError),
+        ([1, 2, 3], ["a", "b", "c"], ValueError),
+        
+        # Non-array-like objects
+        (123, [1, 2, 3], TypeError),
+        ([1, 2, 3], None, TypeError),
+    ]
+)
+def test_mean_absolute_error_exceptions(y_true, y_pred, exception):
+    '''
+    Test mean absolute error raises appropriate exceptions for invalid inputs
+    '''
+    with pytest.raises(exception):
+        m.mean_absolute_error(y_true, y_pred)
 
 
 @pytest.mark.parametrize("y_pred, y_true, expected",


### PR DESCRIPTION
## 0.4.1

## Changed

* All point forecast metrics now validate inputs and raise `ValueError` or `TypeError` when `y_true` and `y_pred` do not meet specifications
* `mean_absolute_percentage_error` and `symmetric_mean_absolute_percentage_error` now raise user warnings when values are close to zero. i.e. inflation of metrics can occur.

## Fixed

* PATCH: point forecast metrics can now handle edge case where `y_true` and `y_pred` inputs are different data types (e.g. `pd.Series` and `np.array`). Prior to v0.4.1 this generated an incorrect metric.  